### PR TITLE
Update installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@
 
 # Install required software:
 
-> sudo apt-get install git lua5.1 lua-lpeg valgrind
+> sudo apt-get install git lua5.1 liblua5.1-dev lua-lpeg
 
 # Clone Céu repository:
 
@@ -14,6 +14,7 @@
 # Run self tests:
 
 > ./run_tests.lua
+> cp ceu /usr/local/bin/  # copy ceu to your path
 
 # Include Céu in your path:
 


### PR DESCRIPTION
* It's necessary to have `lua.h` for `run_tests.lua` to succeed, so `liblua5.1-dev` must be installed.
* Make it reflect the remaining instructions from the [wiki page](http://www.ceu-lang.org/wiki/index.php?title=Céu_Manually)
* Rename to `INSTALL.md`