### PR TITLE
Adding missing package in installation instruction (e.g. liblua5.3-dev).

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://gitter.im/fsantanna/ceu
 ## Install required software:
 
 ```
-$ sudo apt-get install git lua5.3 lua-lpeg liblua5.3-0
+$ sudo apt-get install git lua5.3 lua-lpeg liblua5.3-0 liblua5.3-dev
 ```
 
 (Assuming a Linux/Ubuntu machine.)


### PR DESCRIPTION
Assuming a Linux/Ubuntu machine package liblua5.3-dev is missing.